### PR TITLE
fix custom link examples

### DIFF
--- a/docs/2.0/recipes/custom-link-field.md
+++ b/docs/2.0/recipes/custom-link-field.md
@@ -5,13 +5,13 @@ When you want to add a custom link as a field on your resource that points to a 
 ```ruby
 # with the format_using option
 field :partner_home, as: :text, format_using: -> (url) { link_to(url, url, target: "_blank") } do |model, *args|
-  avo.resources_partners_url model.partner.id
+  avo.resources_partner_url model.partner.id
 end
 
 # with the as_html option
 field :partner_home, as: :text, as_html: true do |model, *args|
   if model.partner.present?
-    link_to model.partner.first_name, avo.resources_partners_url(model.partner.id)
+    link_to model.partner.first_name, avo.resources_partner_url(model.partner.id)
   end
 end
 ```


### PR DESCRIPTION
Link to the `show` page, not the `index` page.