### PR TITLE
Change SimpleMDE refs to EasyMDE

### DIFF
--- a/docs/2.0/fields/markdown.md
+++ b/docs/2.0/fields/markdown.md
@@ -7,7 +7,7 @@ license: community
 
 <img :src="('/assets/img/fields/markdown.jpg')" alt="Trix field" class="border mb-4" />
 
-The `Markdown` field renders a [SimpleMDE Markdown Editor](https://simplemde.com/) and is associated with a text or textarea column in the database.
+The `Markdown` field renders a [EasyMDE Markdown Editor](https://github.com/Ionaru/easy-markdown-editor) and is associated with a text or textarea column in the database.
 `Markdown` field converts text within the editor into raw Markdown text and stores it back in the database.
 
 The Markdown field is hidden from the **Index** view.

--- a/docs/3.0/fields/markdown.md
+++ b/docs/3.0/fields/markdown.md
@@ -7,7 +7,7 @@ license: community
 
 <img :src="('/assets/img/fields/markdown.jpg')" alt="Trix field" class="border mb-4" />
 
-The `Markdown` field renders a [SimpleMDE Markdown Editor](https://simplemde.com/) and is associated with a text or textarea column in the database.
+The `Markdown` field renders a [EasyMDE Markdown Editor](https://github.com/Ionaru/easy-markdown-editor) and is associated with a text or textarea column in the database.
 `Markdown` field converts text within the editor into raw Markdown text and stores it back in the database.
 
 The Markdown field is hidden from the **Index** view.


### PR DESCRIPTION
In concert with https://github.com/avo-hq/avo/pull/1729, update the documentation to refer to the new editor for Markdown fields.