### PR TITLE
Update defined? example on dynamic filters

### DIFF
--- a/docs/3.0/dynamic-filters.md
+++ b/docs/3.0/dynamic-filters.md
@@ -113,8 +113,8 @@ Avo.configure do |config|
   # Other Avo configurations
 end
 
-if defined?(AvoFilters)
-  AvoFilters.configure do |config|
+if defined?(Avo::DynamicFilters)
+  Avo::DynamicFilters.configure do |config|
     config.button_label = "Advanced filters"
     config.always_expanded = true
   end


### PR DESCRIPTION
The current example in the documentation does not correctly apply the config on the dynamic filters

This PR updates the example to use `Avo::DynamicFilters`