### PR TITLE
Add "`heading` has become a field type" section to upgrade guide

### DIFF
--- a/docs/3.0/avo-2-avo-3-upgrade.md
+++ b/docs/3.0/avo-2-avo-3-upgrade.md
@@ -90,6 +90,10 @@ field :status,
 Before, a heading used the `heading` method with a text string or HTML string as an argument.
 Now, it is a field type with an ID. It supports rendering as text and as HTML.
 
+### Actions to take
+
+Rename `heading` to `field`. Give the field an ID and add the `as: :heading` argument.
+
 ```ruby
 # Before
 heading 'User Information'

--- a/docs/3.0/avo-2-avo-3-upgrade.md
+++ b/docs/3.0/avo-2-avo-3-upgrade.md
@@ -86,7 +86,7 @@ field :status,
 ```
 :::
 
-:::option The heading field changed behavior
+:::option `heading` has become a field type
 Before, a heading used the `heading` method with a text string or HTML string as an argument.
 Now, it is a field type with an ID. It supports rendering as text and as HTML.
 

--- a/docs/3.0/avo-2-avo-3-upgrade.md
+++ b/docs/3.0/avo-2-avo-3-upgrade.md
@@ -86,6 +86,29 @@ field :status,
 ```
 :::
 
+:::option The heading field changed behavior
+Before, a heading used the `heading` method with a text string or HTML string as an argument.
+Now, it is a field type with an ID. It supports rendering as text and as HTML.
+
+```ruby
+# Before
+heading 'User Information'
+
+# After
+field :user_information, as: :heading
+# or...
+field :some_id, as: :heading, label: 'User Information'
+
+# Before
+heading '<div class="underline uppercase font-bold">User Information</div>', as_html: true
+
+# After
+field :some_id, as: :heading, as_html: true do
+  '<div class="underline uppercase font-bold">User Information</div>'
+end
+```
+:::
+
 :::option Moved some globals from `Avo::App` to `Avo::Current`
 
 ### Actions to take


### PR DESCRIPTION
The `heading` field has changed to a field type from v2 to v3, but this is not mentioned in the upgrade guide anywhere.

I've added a section here with examples of upgrading from text and from HTML.