### PR TITLE
Update live demo app URL in documentation to point to main.avodemo.com

### DIFF
--- a/docs/2.0/faq.md
+++ b/docs/2.0/faq.md
@@ -76,7 +76,7 @@ All in all **we're confident you'll have the necessary instruments** you need to
 
 ### STI example
 
-For **STI** you can check out the models and resources in the [demo app](https://avodemo.herokuapp.com/).
+For **STI** you can check out the models and resources in the [demo app](https://main.avodemo.com/).
 
  - [person.rb](https://github.com/avo-hq/avodemo/blob/main/app/models/person.rb)
  - [spouse.rb](https://github.com/avo-hq/avodemo/blob/main/app/models/spouse.rb)

--- a/docs/2.0/index.md
+++ b/docs/2.0/index.md
@@ -53,7 +53,7 @@ Please take your time and read the documentation pages to see how Avo interacts 
 1. [Create a Resource](./resources.html#defining-resources)
 1. [Set up authorization](authorization.html)
 1. [Set up licensing](licensing)
-1. [Explore the live demo app](https://avodemo.herokuapp.com)
+1. [Explore the live demo app](https://main.avodemo.com/)
 1. Explore these docs
 1. Enjoy building your app without ever worrying about the admin layer ever again
 1. Explore the [FAQ](faq) pages for guides on how to set up your Avo instance.

--- a/docs/3.0/faq.md
+++ b/docs/3.0/faq.md
@@ -75,7 +75,7 @@ All in all **we're confident you'll have the necessary instruments** you need to
 
 ### STI example
 
-For **STI** you can check out the models and resources in the [demo app](https://avodemo.herokuapp.com/).
+For **STI** you can check out the models and resources in the [demo app](https://main.avodemo.com/).
 
  - [person.rb](https://github.com/avo-hq/avodemo/blob/main/app/models/person.rb)
  - [spouse.rb](https://github.com/avo-hq/avodemo/blob/main/app/models/spouse.rb)

--- a/docs/3.0/index.md
+++ b/docs/3.0/index.md
@@ -53,7 +53,7 @@ Please take your time and read the documentation pages to see how Avo interacts 
 1. [Create a Resource](./resources.html#defining-resources)
 1. [Set up authorization](authorization.html)
 1. [Set up licensing](licensing)
-1. [Explore the live demo app](https://avodemo.herokuapp.com)
+1. [Explore the live demo app](https://main.avodemo.com/)
 1. Explore these docs
 1. Enjoy building your app without ever worrying about the admin layer ever again
 1. Explore the [FAQ](faq) pages for guides on how to set up your Avo instance.


### PR DESCRIPTION
The heroku link is not working and another demo app seems to be in operation, so I replaced the link.Please check it out.

ref. https://github.com/avo-hq/avo/pull/1954