### PR TITLE
Fix typo in example of using link_to_child_resource for field has_many

### DIFF
--- a/docs/2.0/associations.md
+++ b/docs/2.0/associations.md
@@ -50,7 +50,7 @@ You may want to use the `PersonResource` to list all the records, but when your 
 There are two ways you can use this:
 
 1. `self.link_to_child_resource = true` Declare this option on the parent resource. When a user is on the <Index /> view of your the `PersonResource` and clicks on the view button of a `Person` they will be redirected to a `Child` or `Spouse` resource instead of a `Person` resource.
-2. `field :peoples, as: :has_many, link_to_child_resource: false` Use it on a `has_many` field. On the `PersonResource` you may want to show all the related people on the <Show /> page, but when someone click on a record, they are redirected to the inherited `Child` or `Spouse` resource.
+2. `field :peoples, as: :has_many, link_to_child_resource: true` Use it on a `has_many` field. On the `PersonResource` you may want to show all the related people on the <Show /> page, but when someone click on a record, they are redirected to the inherited `Child` or `Spouse` resource.
 
 ## Add custom labels to the associations' pages
 


### PR DESCRIPTION
Fix typo in example of using link_to_child_resource parameter for field of type has_many