### PR TITLE
Adjust docs about Stimulus controllers in Actions

### DIFF
--- a/docs/2.0/stimulus-integration.md
+++ b/docs/2.0/stimulus-integration.md
@@ -127,9 +127,9 @@ export default class extends Controller {
 
 The possible values are `index`, `show`, `edit`, or `new`
 
-## Assign Stimulus controllers to standalone actions
+## Assign Stimulus controllers to actions
 
-Similarly as to resource, you can assign stimulus controller to a standalone action (action that has some embedded form). To do that you can use the `stimulus_controllers` option on the action file.
+Similarly as to resource, you can assign stimulus controller to an action. To do that you can use the `stimulus_controllers` option on the action file.
 
 ```ruby
 class ShowCurrentTime < Avo::BaseAction
@@ -147,7 +147,7 @@ end
 
 The same way as for the resources, Avo will add stimulus target data attributes to [all field wrappers](#field-wrappers-as-targets) and [all input fields](#field-inputs-as-targets).
 
-Unlike with the resource, Avo will not add a specific default controller for each type of the view (`index`, `show`, `edit`) as standalone actions are independent from the view type.
+Unlike with the resource, Avo will not add a specific default controller for each type of the view (`index`, `show`, `edit`).
 Same way, the controllers will not receive the `view` attribute in the DOM, [as in case of resources](#all-controllers-receive-the-view-value).
 
 ## Attach HTML attributes
@@ -680,7 +680,7 @@ export default class extends Controller {
 
 ```js
 // app/javascript/avo.custom.js
-import SampleController from 'controllers/sample_controller'
+import SampleController from "controllers/sample_controller";
 
 // Hook into the stimulus instance provided by Avo
 const application = window.Stimulus;

--- a/docs/3.0/stimulus-integration.md
+++ b/docs/3.0/stimulus-integration.md
@@ -127,12 +127,12 @@ export default class extends Controller {
 
 The possible values are `index`, `show`, `edit`, or `new`
 
-## Assign Stimulus controllers to standalone actions
+## Assign Stimulus controllers to actions
 
-Similarly as to resource, you can assign stimulus controller to a standalone action (action that has some embedded form). To do that you can use the `stimulus_controllers` option on the action file.
+Similarly as to resource, you can assign stimulus controller to an action. To do that you can use the `stimulus_controllers` option on the action file.
 
 ```ruby
-class Avo::Actions::ShowCurrentTime < Avo::BaseAction
+class ShowCurrentTime < Avo::BaseAction
   self.stimulus_controllers = "city-in-country"
 end
 ```
@@ -140,14 +140,14 @@ end
 You can add more and separate them by a space character.
 
 ```ruby
-class Avo::Actions::ShowCurrentTime < Avo::BaseAction
-  self.stimulus_controllers = "city-in-country select-field association-fields"
+class ShowCurrentTime < Avo::BaseAction
+  self.stimulus_controllers = "course-resource select-field association-fields"
 end
 ```
 
 The same way as for the resources, Avo will add stimulus target data attributes to [all field wrappers](#field-wrappers-as-targets) and [all input fields](#field-inputs-as-targets).
 
-Unlike with the resource, Avo will not add a specific default controller for each type of the view (`index`, `show`, `edit`) as standalone actions are independent from the view type.
+Unlike with the resource, Avo will not add a specific default controller for each type of the view (`index`, `show`, `edit`).
 Same way, the controllers will not receive the `view` attribute in the DOM, [as in case of resources](#all-controllers-receive-the-view-value).
 
 ## Attach HTML attributes
@@ -682,7 +682,7 @@ export default class extends Controller {
 
 ```js
 // app/javascript/avo.custom.js
-import SampleController from 'controllers/sample_controller'
+import SampleController from "controllers/sample_controller";
 
 // Hook into the stimulus instance provided by Avo
 const application = window.Stimulus;


### PR DESCRIPTION
As mentioned by @Paul-Bob [here](https://github.com/avo-hq/avodocs/pull/136#issuecomment-1840304032) we're not limiting adding the Stimulus controllers only to standalone Actions, as the docs currently suggest.

I'm removing references to `standalone` actions from the docs about adding custom Stimulus controllers.