### PR TITLE
Update the doc for friendly id to support arrays of slugs

### DIFF
--- a/docs/3.0/customization.md
+++ b/docs/3.0/customization.md
@@ -361,8 +361,12 @@ end
 ```ruby [app/avo/resources/user.rb]
 class Avo::Resources::User < Avo::BaseResource
   self.find_record_method = -> {
-    # We have to add .friendly to the query
-    query.friendly.find! id
+    if id.is_a?(Array)
+      query.where(slug: id)
+    else
+      # We have to add .friendly to the query
+      query.friendly.find id
+    end
   }
 end
 ```


### PR DESCRIPTION
I ran into an issue for a resource using friendly id 

When using a custom action on a model then the id is an array and friendly `find` method does not support array so we need to manually handle that 

Also the doc uses the `find!` method but this is not a friendly method only `find` exists