### PR TITLE
Correct the way to get a dashboard path

### DIFF
--- a/docs/3.0/customization.md
+++ b/docs/3.0/customization.md
@@ -221,7 +221,7 @@ You can also use a lambda function to define that path.
 
 ```ruby{2}
 Avo.configure do |config|
-  config.home_path = -> { avo.dashboard_path(:dashy) }
+  config.home_path = -> { avo_dashboards.dashboard_path(:dashy) }
 end
 ```
 


### PR DESCRIPTION
In the switch from avo 2 to avo 3, the way to get a path to a dashboard changed from:

    avo.dashboard_path(:dashy)

to 

    avo_dashboards.dashboard_path(:dashy)

But the documentation wasn't updated.