### PR TITLE
fix: typo in trix field documentation

### DIFF
--- a/docs/2.0/fields/trix.md
+++ b/docs/2.0/fields/trix.md
@@ -24,7 +24,7 @@ By default, the content of the `Trix` field is not visible on the `Show` view; i
 <!-- @include: ./../common/default_boolean_false.md-->
 :::
 
-:::option `attchments_disabled`
+:::option `attachments_disabled`
 Hides the attachments button from the Trix toolbar.
 
 <!-- @include: ./../common/default_boolean_false.md-->

--- a/docs/3.0/fields/trix.md
+++ b/docs/3.0/fields/trix.md
@@ -24,7 +24,7 @@ By default, the content of the `Trix` field is not visible on the `Show` view; i
 <!-- @include: ./../common/default_boolean_false.md-->
 :::
 
-:::option `attchments_disabled`
+:::option `attachments_disabled`
 Hides the attachments button from the Trix toolbar.
 
 <!-- @include: ./../common/default_boolean_false.md-->


### PR DESCRIPTION
This PR just fix a typo in the trix field documentation 😉 