### PR TITLE
fix: rename instantclick to instant_click

### DIFF
--- a/docs/3.0/customization.md
+++ b/docs/3.0/customization.md
@@ -533,7 +533,7 @@ Supported options with default values:
 ```ruby
   config.turbo = -> do
     {
-      instantclick: true
+      instant_click: true
     }
   end
 ```


### PR DESCRIPTION
https://github.com/avo-hq/avo/pull/2537