### PR TITLE
pagination_defaults

### DIFF
--- a/docs/3.0/resources.md
+++ b/docs/3.0/resources.md
@@ -810,4 +810,22 @@ self.pagination = -> do
 end
 ```
 ![Countless pagination size empty](/assets/img/resources/pagination/countless_empty_size.png)
+
+#### Change pagination defaults
+
+If you want for example all resources to be countless, instead of defining it one by one you can override the pagination defaults.
+
+```ruby
+# avo.rb
+
+Avo.configure do |config|
+  # ...
+end
+
+Avo::Concerns::Pagination::PAGINATION_DEFAULTS = {
+  type: :countless,
+  size: [1, 2, 2, 1],
+}
+
+```
 :::


### PR DESCRIPTION
@adrianthedev should we document this way of overriding defaults or should we implement a way to customize it like:

From https://discord.com/channels/740892036978442260/1225792767754506240/1230879465236594709

```ruby
## == Resource options ==
  # config.resource_controls_placement = :right
  # config.model_resource_mapping = {}
  # config.default_view_type = :table
  # config.per_page = 24
  # config.per_page_steps = [12, 24, 48, 72]
  # config.via_per_page = 8
  config.pagination = {
    ...
  }
```